### PR TITLE
Update Deploy Workflow

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -2,9 +2,10 @@
 name: Deploy static content to Pages
 
 on:
-  # Runs on pushes targeting the default branch
+  # Runs on version bumps, which are tagged with v*.*.*
   push:
-    branches: ['main']
+    tags:
+      - 'v*.*.*'
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
This pull request updates the deployment workflow configuration to trigger deployments based on version tags instead of pushes to the default branch.

Workflow trigger changes:

* [`.github/workflows/deploy.yaml`](diffhunk://#diff-4f9e38227ed64fefb17f4668a7ac4ab55b6149994d5ac2fd96182d5958479b54L5-R8): Updated the `push` event configuration to trigger deployments on tags matching the pattern `v*.*.*` instead of the `main` branch.